### PR TITLE
Fixed the result of "$created_at$" of tweet being strange in some environments

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,3 +1,6 @@
+0.59
+Fixed the result of "$created_at$" of tweet being strange in some environments.
+
 0.58
 The number of characters is now calculated correctly when multibyte characters are included when composing a tweet.
 

--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -1,8 +1,6 @@
-0.59
-Fixed the result of "$created_at$" of tweet being strange in some environments.
-
 0.58
 The number of characters is now calculated correctly when multibyte characters are included when composing a tweet.
+Fixed the result of "$created_at$" of tweet being strange in some environments.
 
 0.57
 Emergency fix for sounds not working on some clients.

--- a/utils.py
+++ b/utils.py
@@ -279,7 +279,7 @@ def class_match(d1, d2):
 
 def parse_date(date,convert=True):
 	ti=datetime.datetime.now()
-	tz=time.altzone
+	tz=time.timezone
 	if convert==True:
 		try:
 			date+=datetime.timedelta(seconds=0-tz)


### PR DESCRIPTION
In the environment using time zone such as JST, fix the "$created_at$" of the tweet is off by 1 hour.
It works fine in my environment, but I haven't been able to test it in other environments, so please test it.