### PR TITLE
implements issue 13 (automatically open a URL in a tweet if there's only one URL)

### DIFF
--- a/GUI/chooser.py
+++ b/GUI/chooser.py
@@ -45,10 +45,7 @@ class ChooseGui(wx.Dialog):
 			user=view.UserViewGui(self.account,[utils.lookup_user_name(self.account,self.returnvalue)],self.returnvalue+"'s profile")
 			user.Show()
 		elif self.type==self.TYPE_URL:
-			if platform.system()!="Darwin":
-				webbrowser.open(self.returnvalue)
-			else:
-				os.system("open "+self.returnvalue)
+			utils.openURL(self.returnvalue)
 		elif self.type==self.TYPE_LIST:
 			l=lists.ListsGui(self.account,utils.lookup_user_name(self.account,self.returnvalue))
 			l.Show()

--- a/GUI/chooser.py
+++ b/GUI/chooser.py
@@ -8,6 +8,12 @@ import platform
 from . import lists, main, misc, view
 
 class ChooseGui(wx.Dialog):
+	
+	#constants for the types we might need to handle
+	TYPE_LIST = "list"
+	TYPE_URL="url"
+	TYPE_PROFILE = "profile"
+
 	def __init__(self,account,title="Choose",text="Choose a thing",list=[],type=""):
 		self.account=account
 		self.type=type
@@ -35,15 +41,15 @@ class ChooseGui(wx.Dialog):
 	def OK(self, event):
 		self.returnvalue=self.chooser.GetValue().strip("@")
 		self.Destroy()
-		if self.type=="profile":
+		if self.type==self.TYPE_PROFILE:
 			user=view.UserViewGui(self.account,[utils.lookup_user_name(self.account,self.returnvalue)],self.returnvalue+"'s profile")
 			user.Show()
-		if self.type=="url":
+		elif self.type==self.TYPE_URL:
 			if platform.system()!="Darwin":
 				webbrowser.open(self.returnvalue)
 			else:
 				os.system("open "+self.returnvalue)
-		if self.type=="list":
+		elif self.type==self.TYPE_LIST:
 			l=lists.ListsGui(self.account,utils.lookup_user_name(self.account,self.returnvalue))
 			l.Show()
 		if self.type=="listr":

--- a/GUI/misc.py
+++ b/GUI/misc.py
@@ -39,7 +39,7 @@ def url_chooser(account,status):
 		urlList=utils.find_urls_in_text(status.message_create['message_data']['text'])
 	else:
 		urlList = utils.find_urls_in_text(status.text)
-	if len(urlList) == 1:
+	if len(urlList) == 1 and globals.prefs.autoOpenSingleURL:
 		utils.openURL(urlList[0])
 	else:
 		chooser.chooser(account,title,prompt,urlList,type)

--- a/GUI/misc.py
+++ b/GUI/misc.py
@@ -39,7 +39,10 @@ def url_chooser(account,status):
 		urlList=utils.find_urls_in_text(status.message_create['message_data']['text'])
 	else:
 		urlList = utils.find_urls_in_text(status.text)
-	chooser.chooser(account,title,prompt,urlList,type)
+	if len(urlList) == 1:
+		utils.openURL(urlList[0])
+	else:
+		chooser.chooser(account,title,prompt,urlList,type)
 
 def follow(account,status):
 	u=utils.get_user_objects_in_tweet(account,status)

--- a/GUI/misc.py
+++ b/GUI/misc.py
@@ -32,10 +32,14 @@ def user_profile(account,status):
 	chooser.chooser(account,"User Profile","Choose user profile",u2,"profile")
 
 def url_chooser(account,status):
+	title="Open URL"
+	prompt="Select a URL?"
+	type=chooser.ChooseGui.TYPE_URL
 	if hasattr(status,"message_create"):
-		chooser.chooser(account,"Open URL","Select a URL?",utils.find_urls_in_text(status.message_create['message_data']['text']),"url")
+		urlList=utils.find_urls_in_text(status.message_create['message_data']['text'])
 	else:
-		chooser.chooser(account,"Open URL","Select a URL?",utils.find_urls_in_text(status.text),"url")
+		urlList = utils.find_urls_in_text(status.text)
+	chooser.chooser(account,title,prompt,urlList,type)
 
 def follow(account,status):
 	u=utils.get_user_objects_in_tweet(account,status)

--- a/GUI/options.py
+++ b/GUI/options.py
@@ -30,6 +30,9 @@ class general(wx.Panel, wx.Dialog):
 		self.wrap=wx.CheckBox(self, -1, "Word wrap in text fields")
 		self.main_box.Add(self.wrap, 0, wx.ALL, 10)
 		self.wrap.SetValue(globals.prefs.wrap)
+		self.autoOpenSingleURL=wx.CheckBox(self, -1, "when getting URLs from a tweet, automatically open the first URL if it is the only one")
+		self.main_box.Add(self.autoOpenSingleURL, 0, wx.ALL, 10)
+		self.autoOpenSingleURL.SetValue(globals.prefs.autoOpenSingleURL)
 
 
 class templates(wx.Panel, wx.Dialog):
@@ -167,6 +170,7 @@ class OptionsGui(wx.Dialog):
 		globals.prefs.messageTemplate=self.templates.messageTemplate.GetValue()
 		globals.prefs.copyTemplate=self.templates.copyTemplate.GetValue()
 		globals.prefs.userTemplate=self.templates.userTemplate.GetValue()
+		globals.prefs.autoOpenSingleURL=self.general.autoOpenSingleURL.GetValue()
 		self.Destroy()
 		if reverse==True:
 			timeline.reverse()

--- a/globals.py
+++ b/globals.py
@@ -78,7 +78,7 @@ def  load():
 	prefs.ask_dismiss=prefs.get("ask_dismiss",True)
 	prefs.reversed=prefs.get("reversed",False)
 	prefs.window_shown=prefs.get("window_shown",True)
-	prefs.auto_open_single_url=prefs.get("auto_open_single_url", False)
+	prefs.autoOpenSingleURL=prefs.get("autoOpenSingleURL", False)
 	prefs.media_player=prefs.get("media_player","")
 	prefs.earcon_audio=prefs.get("earcon_audio",True)
 	prefs.earcon_top=prefs.get("earcon_top",False)

--- a/globals.py
+++ b/globals.py
@@ -78,6 +78,7 @@ def  load():
 	prefs.ask_dismiss=prefs.get("ask_dismiss",True)
 	prefs.reversed=prefs.get("reversed",False)
 	prefs.window_shown=prefs.get("window_shown",True)
+	prefs.auto_open_single_url=prefs.get("auto_open_single_url", False)
 	prefs.media_player=prefs.get("media_player","")
 	prefs.earcon_audio=prefs.get("earcon_audio",True)
 	prefs.earcon_top=prefs.get("earcon_top",False)

--- a/utils.py
+++ b/utils.py
@@ -12,6 +12,7 @@ import requests
 import webbrowser
 import application
 import sound
+import os
 
 url_re=re.compile(r"(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'\".,<>?]))")
 url_re2=re.compile("(?:\w+://|www\.)[^ ,.?!#%=+][^ ]*")

--- a/utils.py
+++ b/utils.py
@@ -508,3 +508,9 @@ def get_account(id):
 		if i.me.id==id:
 			return i
 	return -1
+
+def openURL(url):
+	if platform.system()!="Darwin":
+		webbrowser.open(url)
+	else:
+		os.system(f"open {url}")


### PR DESCRIPTION
This PR implements the feature request in issue 13. If a tweet has a single URL and the user choose the command to open URLs, that single URL is opened immediately instead of a dialog appearing. A setting exists to let the user disable this behavior. It is disabled by default, and the default value used if this setting cannot be found is False.

Please note that this PR also partially switches chooser.ChooseGui to use class-level constants instead of strings when checking for the type to determine how to handle the OK button. This was done so that other files could reference these types by using ChooseGui.TYPE_* instead of matching hard-coded strings. This change is not directly related to issue 13.