### PR TITLE
Issue 19: added a preference to use 24-hour time for tweet timestamps

### DIFF
--- a/GUI/options.py
+++ b/GUI/options.py
@@ -33,6 +33,9 @@ class general(wx.Panel, wx.Dialog):
 		self.autoOpenSingleURL=wx.CheckBox(self, -1, "when getting URLs from a tweet, automatically open the first URL if it is the only one")
 		self.main_box.Add(self.autoOpenSingleURL, 0, wx.ALL, 10)
 		self.autoOpenSingleURL.SetValue(globals.prefs.autoOpenSingleURL)
+		self.use24HourTime=wx.CheckBox(self, -1, "Use 24-hour time for tweet timestamps")
+		self.main_box.Add(self.use24HourTime, 0, wx.ALL, 10)
+		self.use24HourTime.SetValue(globals.prefs.use24HourTime)
 
 
 class templates(wx.Panel, wx.Dialog):
@@ -128,6 +131,7 @@ class OptionsGui(wx.Dialog):
 
 	def OnOK(self, event):
 		refresh=False
+		globals.prefs.use24HourTime = self.general.use24HourTime.GetValue()
 		globals.prefs.ask_dismiss=self.general.ask_dismiss.GetValue()
 		if platform.system()!="Darwin":
 			globals.prefs.invisible=self.advanced.invisible.GetValue()

--- a/globals.py
+++ b/globals.py
@@ -79,6 +79,7 @@ def  load():
 	prefs.reversed=prefs.get("reversed",False)
 	prefs.window_shown=prefs.get("window_shown",True)
 	prefs.autoOpenSingleURL=prefs.get("autoOpenSingleURL", False)
+	prefs.use24HourTime=prefs.get("use24HourTime", False)
 	if platform.system()!="Darwin":
 		prefs.media_player=prefs.get("media_player","QPlay.exe")
 	else:

--- a/utils.py
+++ b/utils.py
@@ -295,6 +295,9 @@ def parse_date(date,convert=True):
 	returnstring=""
 
 	try:
+		timeFormatString = "%I:%M:%S %p"
+		if globals.prefs.use24HourTime:
+			timeFormatString = "%H:%M:%S"
 		if date.year==ti.year:
 			if date.day==ti.day and date.month==ti.month:
 				returnstring=""
@@ -303,10 +306,7 @@ def parse_date(date,convert=True):
 		else:
 			returnstring=date.strftime("%m/%d/%Y, ")
 
-		if returnstring!="":
-			returnstring+=date.strftime("%I:%M:%S %p")
-		else:
-			returnstring=date.strftime("%I:%M:%S %p")
+		returnstring=date.strftime(timeFormatString)
 	except:
 		pass
 	return returnstring


### PR DESCRIPTION
This PR should implement the feature requested in issue 19. A checkbox exists in the general tab of the global settings to toggle between 12- and 24-hour time. 