### PR TITLE
minor fix to "new items" announcement

### DIFF
--- a/GUI/options.py
+++ b/GUI/options.py
@@ -128,6 +128,7 @@ class OptionsGui(wx.Dialog):
 
 	def OnOK(self, event):
 		refresh=False
+		globals.prefs.autoOpenSingleURL = self.general.autoOpenSingleURL
 		globals.prefs.ask_dismiss=self.general.ask_dismiss.GetValue()
 		if platform.system()!="Darwin":
 			globals.prefs.invisible=self.advanced.invisible.GetValue()

--- a/timeline.py
+++ b/timeline.py
@@ -253,7 +253,10 @@ class timeline(object):
 					self.play()
 				globals.prefs.statuses_received+=newitems
 				if speech==True:
-					speak.speak(str(newitems)+" new items.")
+					announcement=f"{newitems} new item"
+					if newitems!=1:
+						announcement+="s"
+					speak.speak(announcement)
 			if self.initial==True:
 				self.initial=False
 #			if globals.currentTimeline==self:


### PR DESCRIPTION
This is a very minor fix. There's a bug where refreshing a timeline always says "items", even if just one item were found, as in "1 new items". This string is now set to "item" if only one item was retrieved.