### PR TITLE
fixed the date never being included in the output string in utils.parse_date() (re-fixes #19)

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -295,18 +295,20 @@ def parse_date(date,convert=True):
 	returnstring=""
 
 	try:
+		dateFormatString = "%m/%d/%Y"
 		timeFormatString = "%I:%M:%S %p"
 		if globals.prefs.use24HourTime:
 			timeFormatString = "%H:%M:%S"
+		#include the date if the date to be output happened before today, else just use the time
 		if date.year==ti.year:
 			if date.day==ti.day and date.month==ti.month:
 				returnstring=""
 			else:
-				returnstring=date.strftime("%m/%d/%Y, ")
+				returnstring=date.strftime(f"{dateFormatString}, ")
 		else:
-			returnstring=date.strftime("%m/%d/%Y, ")
+			returnstring=date.strftime(f"{dateFormatString}, ")
 
-		returnstring=date.strftime(timeFormatString)
+		returnstring+=date.strftime(timeFormatString)
 	except:
 		pass
 	return returnstring


### PR DESCRIPTION
fixed the issue in #19, where the date was always being left out in utils.parse_date(). Note to self: plus signs are kinda important.

I also moved the format string used to format the date to its own variable, just to keep things cleaner. It appeared to be identical in both places where it was defined, though one instance was when the argument's year and the current year matched, and the other was when they didn't match. I'd like to adjust things so the user has more control over all this, such as offering date/time templates as well as different behavior if the years match, but that's a separate topic.